### PR TITLE
Swap order of pipe and end callback on sparqlResponseStream

### DIFF
--- a/lib/SparqlJsonParser.ts
+++ b/lib/SparqlJsonParser.ts
@@ -69,12 +69,12 @@ export class SparqlJsonParser {
       }))
       .on("end", _ => {
         if (!resultsFound) {
-          resultStream.emit("error", new Error("No valid SPARQL query results were found (edited)!"))
+          resultStream.emit("error", new Error("No valid SPARQL query results were found."))
         } else if (!variablesFound) {
           resultStream.emit('variables', []);
         }
       });
-      
+
     return resultStream;
   }
 

--- a/lib/SparqlJsonParser.ts
+++ b/lib/SparqlJsonParser.ts
@@ -87,7 +87,7 @@ export class SparqlJsonParser {
     const bindings: IBindings = {};
     for (const key in rawBindings) {
       const rawValue: any = rawBindings[key];
-      let value: RDF.Term;
+      let value: RDF.Term = null;
       switch (rawValue.type) {
       case 'bnode':
         value = this.dataFactory.blankNode(rawValue.value);

--- a/lib/SparqlJsonParser.ts
+++ b/lib/SparqlJsonParser.ts
@@ -5,9 +5,6 @@ import {Transform} from "readable-stream";
 // tslint:disable-next-line:no-var-requires
 const JsonParser = require('jsonparse');
 
-// Declare function type to avoid errors about optional variable
-type DataFactoryVariableFunction = (value: string) => RDF.Variable;
-
 /**
  * Parser for the SPARQL 1.1 Query Results JSON format.
  * @see https://www.w3.org/TR/sparql11-results-json/
@@ -51,8 +48,7 @@ export class SparqlJsonParser {
     let resultsFound = false;
     jsonParser.onValue = (value: any) => {
       if(jsonParser.key === "vars" && jsonParser.stack.length === 2 && jsonParser.stack[1].key === 'head') {
-        const variableFunction: DataFactoryVariableFunction = this.dataFactory.variable as DataFactoryVariableFunction;
-        resultStream.emit('variables', value.map((v: string) => variableFunction(v)));
+        resultStream.emit('variables', value.map((v: string) => this.dataFactory.variable(v)));
         variablesFound = true;
       } else if(jsonParser.key === "results" && jsonParser.stack.length === 1) {
         resultsFound = true;


### PR DESCRIPTION
There was a bug where the end callback on sparqlResponseStream would produce the error about no results having been found, even when there were results being output. Moving the end callback to after pipe seems to fix it, while keeping the results identical to the original order of the callback and pipe.